### PR TITLE
feat: improve demand RUT validation

### DIFF
--- a/src/app/Components/demandas/identificacion-agricultores/identificacion-agricultores.component.scss
+++ b/src/app/Components/demandas/identificacion-agricultores/identificacion-agricultores.component.scss
@@ -14,6 +14,15 @@
   padding: 0px 30px;
 }
 
+// estilos de validación para RUT
+:host ::ng-deep app-input-text.input-success .text-input {
+  border-color: #28a745;
+}
+
+:host ::ng-deep app-input-text.input-error .text-input {
+  border-color: #fb3b3b;
+}
+
 
 .label-1 {
   font-family: "Roboto Slab", serif;

--- a/src/app/Components/demandas/identificacion-agricultores/identificacion-agricultores.component.ts
+++ b/src/app/Components/demandas/identificacion-agricultores/identificacion-agricultores.component.ts
@@ -10,6 +10,7 @@ import { FormsModule } from '@angular/forms';
 import { TableModule } from 'primeng/table';
 import { DividerModule } from 'primeng/divider';
 import { formatRut } from '../../../utils/formatters';
+import { esRutValido } from '../../../utils/validaciones';
 
 @Component({
   selector: 'app-identificacion-agricultores',
@@ -204,50 +205,14 @@ export class IdentificacionAgricultoresComponent implements OnInit{
     }
   }
 
-  private validarRut(rutRaw: string): boolean {
-    if (!rutRaw) { return false; }
-
-    const rut = rutRaw.replace(/\./g, '').replace(/-/g, '').toUpperCase();
-    if (!/^\d{7,8}[0-9K]$/.test(rut)) { return false; }
-
-    const cuerpo = rut.slice(0, -1);
-    const dv     = rut.slice(-1);
-
-    let suma = 0, mult = 2;
-    for (let i = cuerpo.length - 1; i >= 0; i--) {
-      suma += +cuerpo[i] * mult;
-      mult   = mult === 7 ? 2 : mult + 1;
-    }
-
-    const resto  = 11 - (suma % 11);
-    const dvReal = resto === 11 ? '0' : resto === 10 ? 'K' : String(resto);
-    return dvReal === dv;
-  }
-
-  private formatearRut(rutRaw: string): string {
-    const clean = rutRaw.replace(/\./g, '').replace(/-/g, '').toUpperCase();
-    if (clean.length < 2) { return clean; }
-
-    const cuerpo = clean.slice(0, -1);
-    const dv     = clean.slice(-1);
-    let out = '', i = 0;
-
-    for (let j = cuerpo.length - 1; j >= 0; j--) {
-      out = cuerpo[j] + out;
-      i++;
-      if (i === 3 && j !== 0) { out = '.' + out; i = 0; }
-    }
-    return `${out}-${dv}`;
-  }
-
   onIdentificadorChange(val: string) {
-    this.identificador          = this.formatearRut(val);
-    this.rutIdentificadorValido = this.validarRut(this.identificador);
+    this.identificador = formatRut(val);
+    this.rutIdentificadorValido = esRutValido(val);
   }
 
   onRutRepresentanteChange(val: string) {
-    this.rutRepresentanteLegal      = this.formatearRut(val);
-    this.rutRepresentanteLegalValido = this.validarRut(this.rutRepresentanteLegal);
+    this.rutRepresentanteLegal = formatRut(val);
+    this.rutRepresentanteLegalValido = esRutValido(val);
   }
 
 }

--- a/src/app/utils/validaciones.ts
+++ b/src/app/utils/validaciones.ts
@@ -20,3 +20,27 @@ export const limpiarRut = (rut: string): string => {
     if (!rut) return '';
     return rut.replace(/[\.\-\s]/g, '');
 }
+
+export const esRutValido = (rut: string): boolean => {
+    const cleanRut = limpiarRut(rut).toUpperCase();
+
+    if (!/^\d{7,8}[0-9K]$/.test(cleanRut)) {
+        return false;
+    }
+
+    const cuerpo = cleanRut.slice(0, -1);
+    const dv = cleanRut.slice(-1);
+
+    let suma = 0;
+    let mult = 2;
+
+    for (let i = cuerpo.length - 1; i >= 0; i--) {
+        suma += parseInt(cuerpo[i], 10) * mult;
+        mult = mult === 7 ? 2 : mult + 1;
+    }
+
+    const resto = 11 - (suma % 11);
+    const dvReal = resto === 11 ? '0' : resto === 10 ? 'K' : String(resto);
+
+    return dv === dvReal;
+}


### PR DESCRIPTION
## Summary
- add shared Chilean RUT validator
- wire validation into demand identification form
- show green/red borders when RUT is valid/invalid

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless --progress=false` *(fails: no output produced)*

------
https://chatgpt.com/codex/tasks/task_e_689111fd95ec832188b3539698440adc