### PR TITLE
feat: valida agricultor fallecido

### DIFF
--- a/src/app/Components/demandas/identificacion-agricultores/identificacion-agricultores.component.ts
+++ b/src/app/Components/demandas/identificacion-agricultores/identificacion-agricultores.component.ts
@@ -150,19 +150,29 @@ export class IdentificacionAgricultoresComponent implements OnInit{
   identificarAgricultor() {
     const mostrarCampos = true;
     if (this.tipoAgricultor.idTipoUsuario === 1 && !this.esEditar) {
-      this.demandaService.getPersonaNatural(this.identificador).subscribe({
-        next: (resp) => {
-          this.personaNatural = resp
-          this.nombreAgricultor = resp.nombreCompleto
-          this.rutAgricultor = formatRut(resp.rut)
-          this.edadAgricultor = resp.edad.toString()
-          this.sexoAgricultor = resp.sexo === 'M' ? 'Masculino' : 'Femenino'
-          this.acreditacionAgricultor = resp.estadoAcreditacion ? 'Acreditado' : 'No acreditado'
-          this.informacionAgricultorOk = true
-          this.identificadorOk.emit({ id: this.identificador, nombreUsuario: this.nombreAgricultor, mostrarCampos });
-          this.identificador = formatRut(resp.rut);
+      this.demandaService.estaFallecido(this.identificador).subscribe({
+        next: (fallecido) => {
+          if (fallecido) {
+            alert('Persona fallecida!');
+            return;
+          }
+          this.demandaService.getPersonaNatural(this.identificador).subscribe({
+            next: (resp) => {
+              this.personaNatural = resp
+              this.nombreAgricultor = resp.nombreCompleto
+              this.rutAgricultor = formatRut(resp.rut)
+              this.edadAgricultor = resp.edad.toString()
+              this.sexoAgricultor = resp.sexo === 'M' ? 'Masculino' : 'Femenino'
+              this.acreditacionAgricultor = resp.estadoAcreditacion ? 'Acreditado' : 'No acreditado'
+              this.informacionAgricultorOk = true
+              this.identificadorOk.emit({ id: this.identificador, nombreUsuario: this.nombreAgricultor, mostrarCampos });
+              this.identificador = formatRut(resp.rut);
+              this.mostrarCamposAgricultor = mostrarCampos;
+            }
+          })
         }
       })
+      return;
     }
     if (this.tipoAgricultor.idTipoUsuario === 3 && !this.esEditar) {
       this.demandaService.getGrupoInformal(this.identificador).subscribe({
@@ -172,10 +182,10 @@ export class IdentificacionAgricultoresComponent implements OnInit{
           this.nombreRepresentanteAgricultor = resp.representante
           this.informacionAgricultorOk = true
           this.identificadorOk.emit({ id: this.identificador, nombreUsuario: this.nombreRepresentanteAgricultor, mostrarCampos });
+          this.mostrarCamposAgricultor = mostrarCampos;
         }
       })
     }
-    this.mostrarCamposAgricultor = mostrarCampos;
   }
 
   private camposEdicion(): void {

--- a/src/app/services/demanda.service.ts
+++ b/src/app/services/demanda.service.ts
@@ -32,6 +32,10 @@ export class DemandaService {
     return this.http.get<PersonaNatural>(`${this.apiUrl}/agricultores/personaNatural/${rut}`, { headers: this.getHeaders() });
   }
 
+  estaFallecido(rut: string): Observable<boolean> {
+    return this.http.get<boolean>(`${this.apiUrl}/agricultores/estaFallecido/${rut}`, { headers: this.getHeaders() });
+  }
+
   getPersonaJuridica(rut: string): Observable<PersonaJuridica> {
     return this.http.get<PersonaJuridica>(`${this.apiUrl}/agricultores/personaJuridica/${rut}`, { headers: this.getHeaders() });
   }


### PR DESCRIPTION
## Summary
- agrega método para verificar fallecidos en servicio de demandas
- alerta al usuario si el rut consultado pertenece a un fallecido

## Testing
- `npm test` *(falla: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68922b51e01c8321a011aa0afc63370c